### PR TITLE
feat: enable using existing resource group

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -240,6 +240,12 @@
 							"default_value": "rag-services",
 							"description": "The name of the resource group that is created by this solution. The actual name is prefixed with the value of the input 'prefix'.  All resources created by this solution are deployed in this resource group. ",
 							"required": false
+						},						{
+							"key": "existing_resource_group_name",
+							"type": "string",
+							"default_value": "__NULL__",
+							"description": "The name of an existing resource group that is used by this solution. Prefix is NOT used for existing resource group.  All resources created by this solution are deployed in this resource group. ",
+							"required": false
 						},
 						{
 							"key": "watsonx_admin_api_key",

--- a/stack_definition.json
+++ b/stack_definition.json
@@ -27,6 +27,13 @@
       "hidden": false
     },
     {
+      "name": "existing_resource_group_name",
+      "required": false,
+      "type": "string",
+      "hidden": false,
+      "default": null
+    },
+    {
       "name": "region",
       "required": false,
       "type": "string",
@@ -113,6 +120,34 @@
         {
           "name": "devops_resource_group_name",
           "value": "ref:../../inputs/resource_group_name"
+        },
+        {
+          "name": "existing_security_resource_group_name",
+          "value": "ref:../../inputs/existing_resource_group_name"
+        },
+        {
+          "name": "existing_audit_resource_group_name",
+          "value": "ref:../../inputs/existing_resource_group_name"
+        },
+        {
+          "name": "existing_observability_resource_group_name",
+          "value": "ref:../../inputs/existing_resource_group_name"
+        },
+        {
+          "name": "existing_management_resource_group_name",
+          "value": "ref:../../inputs/existing_resource_group_name"
+        },
+        {
+          "name": "existing_workload_resource_group_name",
+          "value": "ref:../../inputs/existing_resource_group_name"
+        },
+        {
+          "name": "existing_edge_resource_group_name",
+          "value": "ref:../../inputs/existing_resource_group_name"
+        },
+        {
+          "name": "existing_devops_resource_group_name",
+          "value": "ref:../../inputs/existing_resource_group_name"
         },
         {
           "name": "provision_trusted_profile_projects",


### PR DESCRIPTION
### Description

The latest Account Infrastructure Base DA supports using existing resources groups, this update adds passing a new optional  input `existing_resource_group_name` from the stack to the corresponding inputs of Account Infrastructure Base DA.
If `existing_resource_group_name` is supplied, the `resource_group_name` parameter value is ignored.
Note that Account Infrastructure Base DA does not use `prefix` parameter when the existing resource group names are supplied, so the `existing_resource_group_name` value in the stack needs to be the actual full resource group name.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [X] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

If `existing_resource_group_name` is supplied, this resource group will be used instead of provisioning a new one. The `resource_group_name` parameter value is ignored  in this case.
Note that Account Infrastructure Base DA does not use `prefix` parameter when the existing resource group names are supplied, so the `existing_resource_group_name` value in the stack needs to be the actual full resource group name.


### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
